### PR TITLE
Write "\n" to end of jsons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tiny JSON database in Golang
 
 ### Installation
 
-Install using `go get github.com/nanobox-io/golang-scribble`.
+Install using `go get github.com/sdomino/scribble`.
 
 ### Usage
 

--- a/example/fishing.go
+++ b/example/fishing.go
@@ -3,8 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-
-	scribble "github.com/nanobox-io/golang-scribble"
+	"github.com/sdomino/scribble"
 )
 
 // a fish

--- a/scribble.go
+++ b/scribble.go
@@ -114,6 +114,9 @@ func (d *Driver) Write(collection, resource string, v interface{}) error {
 		return err
 	}
 
+	// add newline to the end
+	b = append(b, byte('\n'))
+
 	// write marshaled data to the temp file
 	if err := ioutil.WriteFile(tmpPath, b, 0644); err != nil {
 		return err


### PR DESCRIPTION
Every file should end with \n for better readability.
Also corrects mistakes from previous commits.