### PR TITLE
Replace ioutil with os package and add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module scribble
+
+go 1.25.1
+
+require (
+	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25
+	github.com/sdomino/scribble v0.0.0-20230717151034-b95d4df19aa8
+)

--- a/scribble.go
+++ b/scribble.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -128,7 +127,7 @@ func write(dir, tmpPath, dstPath string, v interface{}) error {
 	b = append(b, byte('\n'))
 
 	// write marshaled data to the temp file
-	if err := ioutil.WriteFile(tmpPath, b, 0644); err != nil {
+	if err := os.WriteFile(tmpPath, b, 0644); err != nil {
 		return err
 	}
 
@@ -158,7 +157,7 @@ func (d *Driver) Read(collection, resource string, v interface{}) error {
 
 func read(record string, v interface{}) error {
 
-	b, err := ioutil.ReadFile(record + ".json")
+	b, err := os.ReadFile(record + ".json")
 	if err != nil {
 		return err
 	}
@@ -181,7 +180,7 @@ func (d *Driver) ReadAll(collection string) ([][]byte, error) {
 
 	// read all the files in the transaction.Collection; an error here just means
 	// the collection is either empty or doesn't exist
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +188,7 @@ func (d *Driver) ReadAll(collection string) ([][]byte, error) {
 	return readAll(files, dir)
 }
 
-func readAll(files []os.FileInfo, dir string) ([][]byte, error) {
+func readAll(files []os.DirEntry, dir string) ([][]byte, error) {
 	// the files read from the database
 	var records [][]byte
 
@@ -197,7 +196,7 @@ func readAll(files []os.FileInfo, dir string) ([][]byte, error) {
 	// append the files to the collection of read
 	for _, file := range files {
 
-		b, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+		b, err := os.ReadFile(filepath.Join(dir, file.Name()))
 
 		if err != nil {
 			return nil, err
@@ -235,7 +234,7 @@ func (d *Driver) Delete(collection, resource string) error {
 
 	// remove file
 	case fi.Mode().IsRegular():
-		return os.RemoveAll(dir + ".json")
+		return os.Remove(dir + ".json")
 	}
 
 	return nil

--- a/scribble_test.go
+++ b/scribble_test.go
@@ -5,12 +5,15 @@ import (
 	"testing"
 )
 
-//
 type Fish struct {
 	Type string `json:"type"`
 }
 
-//
+// Testing json.MarshalIndent error
+type Unmarshalable struct {
+	Ch chan struct{}
+}
+
 var (
 	db         *Driver
 	database   = "./deep/school"
@@ -21,7 +24,6 @@ var (
 	bluefish   = Fish{Type: "blue"}
 )
 
-//
 func TestMain(m *testing.M) {
 
 	// remove any thing for a potentially failed previous test
@@ -62,7 +64,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-//
 func TestWriteAndRead(t *testing.T) {
 
 	createDB()
@@ -85,7 +86,6 @@ func TestWriteAndRead(t *testing.T) {
 	destroySchool()
 }
 
-//
 func TestReadall(t *testing.T) {
 
 	createDB()
@@ -103,7 +103,20 @@ func TestReadall(t *testing.T) {
 	destroySchool()
 }
 
-//
+// Testing reading all from a collection that does not exist.
+func TestReadAll_NonExistentCollection(t *testing.T) {
+	createDB()
+
+	// Be sure the collection does not exist
+	os.RemoveAll(db.dir + "/nonexistentcollection")
+
+	_, err := db.ReadAll("nonexistentcollection")
+	if err == nil {
+		t.Error("Expected error when reading from non-existent collection, got nil")
+	}
+	destroySchool()
+}
+
 func TestWriteAndReadEmpty(t *testing.T) {
 
 	createDB()
@@ -126,7 +139,50 @@ func TestWriteAndReadEmpty(t *testing.T) {
 	destroySchool()
 }
 
-//
+// Testing that write returns an error when json.MarshalIndent fails.
+func TestWrite_MarshalError(t *testing.T) {
+	createDB()
+
+	unmarshalable := Unmarshalable{}
+	if err := db.Write(collection, "unmarshalable", unmarshalable); err == nil {
+		t.Error("Expected error when marshalling unmarshalable type, got nil")
+	}
+	destroySchool()
+}
+
+// Testing reading a resource that does not exist.
+func TestRead_NonExistentResource(t *testing.T) {
+	createDB()
+
+	if err := db.Read(collection, "nonexistentfish", &onefish); err == nil {
+		t.Error("Expected error when reading non-existent resource, got nil")
+	}
+	destroySchool()
+}
+
+// Testing deleting a resource that does not exist.
+func TestDelete_NonExistentResource(t *testing.T) {
+	createDB()
+
+	if err := db.Delete(collection, "nonexistentfish"); err == nil {
+		t.Error("Expected error when deleting non-existent resource, got nil")
+	}
+	destroySchool()
+}
+
+// Testing deleting a collection that does not exist.
+func TestDelete_NonExistentCollection(t *testing.T) {
+	createDB()
+
+	// Ensure the collection does not exist
+	os.RemoveAll(db.dir + "/nonexistentcollection")
+
+	if err := db.Delete("nonexistentcollection", "somefish"); err == nil {
+		t.Error("Expected error when deleting from non-existent collection, got nil")
+	}
+	destroySchool()
+}
+
 func TestDelete(t *testing.T) {
 
 	createDB()
@@ -149,7 +205,6 @@ func TestDelete(t *testing.T) {
 	destroySchool()
 }
 
-//
 func TestDeleteall(t *testing.T) {
 
 	createDB()


### PR DESCRIPTION
Replaces deprecated ioutil functions with their os equivalents in scribble.go. Updates readAll to use os.DirEntry instead of os.FileInfo. Adds new tests for error cases in scribble_test.go, including handling of non-existent collections/resources and marshal errors. Adds go.mod for module and dependency management.